### PR TITLE
Update mixer setting in iql.yaml.

### DIFF
--- a/src/config/algs/iql.yaml
+++ b/src/config/algs/iql.yaml
@@ -17,6 +17,6 @@ target_update_interval: 200
 agent_output_type: "q"
 learner: "q_learner"
 double_q: True
-mixer: None
+mixer:
 
 name: "iql"


### PR DESCRIPTION
Specifying "None" instead of leaving it blank was resulting in the following error:

```
Traceback (most recent calls WITHOUT Sacred internals):
  File "src/main.py", line 35, in my_main
    run(_run, config, _log)
  File "/Users/Kasim/Projects/ml/pymarl/src/run.py", line 48, in run
    run_sequential(args=args, logger=logger)
  File "/Users/Kasim/Projects/ml/pymarl/src/run.py", line 114, in run_sequential
    learner = le_REGISTRY[args.learner](mac, buffer.scheme, logger, args)
  File "/Users/Kasim/Projects/ml/pymarl/src/learners/q_learner.py", line 26, in __init__
    raise ValueError("Mixer {} not recognised.".format(args.mixer))
ValueError: Mixer None not recognised.
```